### PR TITLE
Base methods

### DIFF
--- a/build.js
+++ b/build.js
@@ -16,6 +16,17 @@ exec(cmd, function (error, stdout, stderr) {
 
 var thunderpath = conf.thunderpath
 
+execSync('echo "# base methods\n" > markdown/base-methods.md')
+execSync('echo "Here is complete documentation for both the base and data class methods.\n" >> markdown/base-methods.md')
+execSync('myopts ' + thunderpath + 'base.py -c Base >> markdown/base-methods.md')
+
+execSync('echo "# data methods\n" >> markdown/base-methods.md')
+execSync('myopts ' + thunderpath + 'base.py -c Data >> markdown/base-methods.md')
+
+execSync('echo "# block methods\n" > markdown/block-methods.md')
+execSync('echo "Here is complete documentation for the methods on blocks.\n" >> markdown/block-methods.md')
+execSync('myopts ' + thunderpath + '/blocks/blocks.py -c Blocks >> markdown/block-methods.md')
+
 execSync('echo "# image loading\n" > markdown/image-loading.md')
 execSync('echo "Here is complete documentation for loading image data.\n" >> markdown/image-loading.md')
 execSync('myopts ' + thunderpath + 'images/readers.py >> markdown/image-loading.md')

--- a/contents.js
+++ b/contents.js
@@ -8,6 +8,8 @@ module.exports = {
   },
   'data types': {
     'overview': 'data-types.md',
+    'base methods': 'base-methods.md',
+    'block methods': 'block-methods.md',
     'image loading': 'image-loading.md',
     'image methods': 'image-methods.md',
     'series loading': 'series-loading.md',

--- a/contents.js
+++ b/contents.js
@@ -9,11 +9,11 @@ module.exports = {
   'data types': {
     'overview': 'data-types.md',
     'base methods': 'base-methods.md',
-    'block methods': 'block-methods.md',
     'image loading': 'image-loading.md',
     'image methods': 'image-methods.md',
     'series loading': 'series-loading.md',
-    'series methods': 'series-methods.md'
+    'series methods': 'series-methods.md',
+    'block methods': 'block-methods.md'
   },
   'packages': {
     'analyses': {

--- a/markdown/base-methods.md
+++ b/markdown/base-methods.md
@@ -1,0 +1,366 @@
+# base methods
+
+Here is complete documentation for the base class methods.
+
+#### `astype(dtype, casting='unsafe')`
+
+Cast values to the specified type.
+
+#### `cache()`
+
+Enable in-memory caching (Spark only).
+
+#### `clip(min=None, max=None)`
+
+Clip values above and below.
+
+- **`min`** `scalar or array-like`
+
+   Minimum value. If array, will be broadcasted
+
+- **`max`** `scalar or array-like`
+
+   Maximum value. If array, will be broadcasted.
+
+#### `coalesce(npartitions)`
+
+Coalesce data (Spark only).
+
+- **`npartitions`** `int`
+
+   Number of partitions after coalescing.
+
+#### `compute()`
+
+Force lazy computations to execute for datasets backed by Spark (Spark only).
+
+#### `count()`
+
+Explicit count of elements.
+
+#### `dotdivide(other)`
+
+Elementwise divison.
+
+See also
+--------
+   elementwise
+
+#### `dottimes(other)`
+
+Elementwise multiplication.
+
+See also
+--------
+   elementwise
+
+#### `element_wise(other, op)`
+
+Apply an elementwise operation to data.
+
+Both self and other data must have the same mode.
+If self is in local mode, other can also be a numpy array.
+Self and other must have the same shape, or other must be a scalar.
+
+- **`other`** `Data or numpy array`
+
+      Data to apply elementwise operation to
+
+- **`op`** `function`
+
+   Binary operator to use for elementwise operations, e.g. add, subtract
+
+#### `filter(func)`
+
+Filter array along an axis.
+
+Applies a function which should evaluate to boolean,
+along a single axis or multiple axes. Array will be
+aligned so that the desired set of axes are in the
+keys, which may require a transpose/reshape.
+
+- **`func`** `function`
+
+   Function to apply, should return boolean
+
+- **`axis`** `tuple or int` `optional` `default=(0,)`
+
+   Axis or multiple axes to filter along.
+
+#### `first()`
+
+Return first element.
+
+#### `iscached()`
+
+Get whether object is cached.
+
+#### `map(func, **kwargs)`
+
+Map a function over elements.
+
+#### `map(func, value_shape=None, dtype=None, with_keys=False)`
+
+Apply an array -> array function across an axis.
+
+Array will be aligned so that the desired set of axes
+are in the keys, which may require a transpose/reshape.
+
+- **`func`** `function`
+
+   Function of a single array to apply. If with_keys=True,
+function should be of a (tuple, array) pair.
+
+- **`axis`** `tuple or int` `optional` `default=(0,)`
+
+   Axis or multiple axes to apply function along.
+
+- **`value_shape`** `tuple` `optional` `default=None`
+
+   Known shape of values resulting from operation. Only
+valid in spark mode.
+
+dtype: numpy.dtype, optional, default=None
+Known shape of dtype resulting from operation. Only
+valid in spark mode.
+
+- **`with_keys`** `bool` `optional` `default=False`
+
+   Include keys as an argument to the function
+
+#### `max()`
+
+Maximum of values computed along the appropriate dimension.
+
+#### `mean()`
+
+Mean of values computed along the appropriate dimension.
+
+#### `min()`
+
+Minimum of values computed along the appropriate dimension.
+
+#### `minus(other)`
+
+Elementwise subtraction.
+
+See also
+--------
+   elementwise
+
+#### `npartitions()`
+
+Get number of partitions.
+
+#### `plus(other)`
+
+Elementwise addition.
+
+See also
+--------
+   elementwise
+
+#### `repartition(npartitions)`
+
+Repartition data (Spark only).
+
+- **`npartitions`** `int`
+
+   Number of partitions after repartitions.
+
+#### `std()`
+
+Standard deviation computed of values along the appropriate dimension.
+
+#### `sum()`
+
+Sum of values computed along the appropriate dimension.
+
+#### `toarray()`
+
+Return all records to the driver as a numpy array
+
+This will be slow for large datasets, and may exhaust the available memory on the driver.
+
+#### `tolocal()`
+
+Convert data to local mode.
+
+#### `tordd()`
+
+Return an RDD for datasets backed by Spark (Spark only).
+
+#### `tospark()`
+
+Convert data to Spark.
+
+#### `uncache()`
+
+Enable in-memory caching.
+
+#### `var()`
+
+Variance of values computed along the appropriate dimension.
+# data methods
+
+Here is complete documentation for the data class methods.
+
+#### `astype(dtype, casting='unsafe')`
+
+Cast values to the specified type.
+
+#### `clip(min=None, max=None)`
+
+Clip values above and below.
+
+- **`min`** `scalar or array-like`
+
+   Minimum value. If array, will be broadcasted
+
+- **`max`** `scalar or array-like`
+
+   Maximum value. If array, will be broadcasted.
+
+#### `count()`
+
+Explicit count of elements.
+
+#### `dotdivide(other)`
+
+Elementwise divison.
+
+See also
+--------
+   elementwise
+
+#### `dottimes(other)`
+
+Elementwise multiplication.
+
+See also
+--------
+   elementwise
+
+#### `element_wise(other, op)`
+
+Apply an elementwise operation to data.
+
+Both self and other data must have the same mode.
+If self is in local mode, other can also be a numpy array.
+Self and other must have the same shape, or other must be a scalar.
+
+- **`other`** `Data or numpy array`
+
+      Data to apply elementwise operation to
+
+- **`op`** `function`
+
+   Binary operator to use for elementwise operations, e.g. add, subtract
+
+#### `filter(func)`
+
+Filter array along an axis.
+
+Applies a function which should evaluate to boolean,
+along a single axis or multiple axes. Array will be
+aligned so that the desired set of axes are in the
+keys, which may require a transpose/reshape.
+
+- **`func`** `function`
+
+   Function to apply, should return boolean
+
+- **`axis`** `tuple or int` `optional` `default=(0,)`
+
+   Axis or multiple axes to filter along.
+
+#### `first()`
+
+Return first element.
+
+#### `map(func, **kwargs)`
+
+Map a function over elements.
+
+#### `map(func, value_shape=None, dtype=None, with_keys=False)`
+
+Apply an array -> array function across an axis.
+
+Array will be aligned so that the desired set of axes
+are in the keys, which may require a transpose/reshape.
+
+- **`func`** `function`
+
+   Function of a single array to apply. If with_keys=True,
+function should be of a (tuple, array) pair.
+
+- **`axis`** `tuple or int` `optional` `default=(0,)`
+
+   Axis or multiple axes to apply function along.
+
+- **`value_shape`** `tuple` `optional` `default=None`
+
+   Known shape of values resulting from operation. Only
+valid in spark mode.
+
+dtype: numpy.dtype, optional, default=None
+Known shape of dtype resulting from operation. Only
+valid in spark mode.
+
+- **`with_keys`** `bool` `optional` `default=False`
+
+   Include keys as an argument to the function
+
+#### `max()`
+
+Maximum of values computed along the appropriate dimension.
+
+#### `mean()`
+
+Mean of values computed along the appropriate dimension.
+
+#### `min()`
+
+Minimum of values computed along the appropriate dimension.
+
+#### `minus(other)`
+
+Elementwise subtraction.
+
+See also
+--------
+   elementwise
+
+#### `plus(other)`
+
+Elementwise addition.
+
+See also
+--------
+   elementwise
+
+#### `std()`
+
+Standard deviation computed of values along the appropriate dimension.
+
+#### `sum()`
+
+Sum of values computed along the appropriate dimension.
+
+#### `toarray()`
+
+Return all records to the driver as a numpy array
+
+This will be slow for large datasets, and may exhaust the available memory on the driver.
+
+#### `tolocal()`
+
+Convert data to local mode.
+
+#### `tospark()`
+
+Convert data to Spark.
+
+#### `var()`
+
+Variance of values computed along the appropriate dimension.

--- a/markdown/block-methods.md
+++ b/markdown/block-methods.md
@@ -1,0 +1,37 @@
+# block methods
+
+Here is complete documentation for the methods on blocks.
+
+#### `collect_blocks()`
+
+Collect the blocks in a list
+
+#### `count()`
+
+Explicit count of the number of items.
+
+For lazy or distributed data, will force a computation.
+
+#### `first()`
+
+Return the first element.
+
+#### `map_generic(func)`
+
+Apply an arbitrary array -> object function to each blocks.
+
+#### `map(func, value_shape=None, dtype=None)`
+
+Apply an array -> array function to each block
+
+#### `toarray()`
+
+Convert blocks to local ndarray
+
+#### `toimages()`
+
+Convert blocks to images.
+
+#### `toseries()`
+
+Converts blocks to series.

--- a/markdown/data-types.md
+++ b/markdown/data-types.md
@@ -14,7 +14,7 @@ The `series` data type in Thunder is used to represent a collection of one-dimen
 
 ## both
 
-Although both `images` and `series` have domain-specific methods, there are several methods shared by both, including simple aggregations like `mean` and `std`, and generic functional operators like `map` and `reduce`. 
+Although both `images` and `series` have domain-specific methods, there are several methods shared by both, including simple aggregations like `mean` and `std`, and generic functional operators like `map` and `reduce`. These come from the shred superclass `data` that is a subclass of the `base` class. The conversion methods between `images` and `series` are preformed via an intermediate data type `blocks` that is also a subclass of `base`.
 
 You'll find yourself using `map` anytime you want to apply a generic function to each record, i.e. each individual image or series. This operation will automatically be parallelized in distributed mode. As an example of `map`, this code snippet generates random `series` data and then adds `2` and computes the mean of each record
 

--- a/markdown/data-types.md
+++ b/markdown/data-types.md
@@ -14,7 +14,7 @@ The `series` data type in Thunder is used to represent a collection of one-dimen
 
 ## both
 
-Although both `images` and `series` have domain-specific methods, there are several methods shared by both, including simple aggregations like `mean` and `std`, and generic functional operators like `map` and `reduce`. These come from the shred superclass `data` that is a subclass of the `base` class. The conversion methods between `images` and `series` are preformed via an intermediate data type `blocks` that is also a subclass of `base`.
+Although both `images` and `series` have domain-specific methods, there are several methods shared by both, including simple aggregations like `mean` and `std`, and generic functional operators like `map` and `reduce`. These come from the shared superclass `data` that is a subclass of the `base` class. The conversion methods between `images` and `series` are preformed via an intermediate data type `blocks` that is also a subclass of `base`.
 
 You'll find yourself using `map` anytime you want to apply a generic function to each record, i.e. each individual image or series. This operation will automatically be parallelized in distributed mode. As an example of `map`, this code snippet generates random `series` data and then adds `2` and computes the mean of each record
 


### PR DESCRIPTION
@freeman-lab @sethvincent  Thanks for getting me set up on this.
This would solve #2 
The only problem I see is that the conversion to markdown of the:

``` python
"""
see also
--------
"""
```

Is not really working, check out the base and data class methods.
We can either fix it in `myops` or remove from `thunder`, what do you think?
